### PR TITLE
Added support for mapping C-struct members to Ar-struct members

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,13 @@ else()
     set(CMAKE_CXX_STANDARD 17)
 endif()
 
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "^(Apple)?Clang$" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof")
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if (${CMAKE_SYSTEM_NAME_ID} MATCHES "Linux")
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -pthread")
 endif()
 

--- a/src/module/random.cc
+++ b/src/module/random.cc
@@ -172,6 +172,7 @@ const TypeInfo *rdengine_bases[] = {
 
 const ObjectSlots rdengine_obj = {
         rdengine_methods,
+        nullptr,
         rdengine_bases,
         nullptr,
         nullptr,

--- a/src/object/CMakeLists.txt
+++ b/src/object/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC
         datatype/map.cc
         datatype/module.cc
         datatype/namespace.cc
+        datatype/nativewrap.cc
         datatype/nil.cc
         datatype/option.cc
         datatype/set.cc

--- a/src/object/arobject.cc
+++ b/src/object/arobject.cc
@@ -70,7 +70,8 @@ const ObjectSlots type_obj = {
         nullptr,
         (BinaryOp) type_get_static_attr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 bool type_is_true(ArObject *self) {

--- a/src/object/arobject.h
+++ b/src/object/arobject.h
@@ -278,7 +278,10 @@ ArObject *prefix##name##_fn(ArObject *func, ArObject *self, ArObject **argv, ArS
 #define AR_MAP_SLOT(object)         (AR_GET_TYPE(object)->map_actions)
 #define AR_NUMBER_SLOT(object)      (AR_GET_TYPE(object)->number_actions)
 #define AR_OBJECT_SLOT(object)      (AR_GET_TYPE(object)->obj_actions)
-#define AR_GET_NSOFF(obj)           ((ArObject **) (((unsigned char *) (obj)) + AR_GET_TYPE(obj)->obj_actions->nsoffset))
+
+#define AR_GET_NSOFF(obj)           (AR_OBJECT_SLOT(obj) != nullptr ? \
+    ((ArObject **) (((unsigned char *) (obj)) + AR_OBJECT_SLOT(obj)->nsoffset)) : nullptr)
+
 #define AR_SEQUENCE_SLOT(object)    (AR_GET_TYPE(object)->sequence_actions)
 
     ArObject *ArObjectGCNew(const TypeInfo *type);

--- a/src/object/arobject.h
+++ b/src/object/arobject.h
@@ -278,6 +278,7 @@ ArObject *prefix##name##_fn(ArObject *func, ArObject *self, ArObject **argv, ArS
 #define AR_MAP_SLOT(object)         (AR_GET_TYPE(object)->map_actions)
 #define AR_NUMBER_SLOT(object)      (AR_GET_TYPE(object)->number_actions)
 #define AR_OBJECT_SLOT(object)      (AR_GET_TYPE(object)->obj_actions)
+#define AR_GET_NSOFF(obj)           ((ArObject **) (((unsigned char *) (obj)) + AR_GET_TYPE(obj)->obj_actions->nsoffset))
 #define AR_SEQUENCE_SLOT(object)    (AR_GET_TYPE(object)->sequence_actions)
 
     ArObject *ArObjectGCNew(const TypeInfo *type);

--- a/src/object/arobject.h
+++ b/src/object/arobject.h
@@ -137,6 +137,8 @@ ArObject *prefix##name##_fn(ArObject *func, ArObject *self, ArObject **argv, ArS
         BinaryOp get_static_attr;
         BoolTernOp set_attr;
         BoolTernOp set_static_attr;
+
+        int nsoffset;
     };
 
     struct OpSlots {

--- a/src/object/arobject.h
+++ b/src/object/arobject.h
@@ -104,6 +104,17 @@ ArObject *prefix##name##_fn(ArObject *func, ArObject *self, ArObject **argv, ArS
 
 #define ARGON_METHOD_SENTINEL   {nullptr, nullptr, nullptr, 0, false}
 
+    enum class NativeMemberType {
+        // TODO: fill
+    };
+
+    struct NativeMember {
+        const char *name;
+        int offset;
+        NativeMemberType type;
+        bool readonly;
+    };
+
     using BufferGetFn = bool (*)(struct ArObject *obj, ArBuffer *buffer, ArBufferFlags flags);
     using BufferRelFn = void (*)(ArBuffer *buffer);
     struct BufferSlots {
@@ -131,6 +142,7 @@ ArObject *prefix##name##_fn(ArObject *func, ArObject *self, ArObject **argv, ArS
 
     struct ObjectSlots {
         const NativeFunc *methods;
+        const NativeMember *members;
         const TypeInfo **traits;
 
         BinaryOp get_attr;

--- a/src/object/arobject.h
+++ b/src/object/arobject.h
@@ -105,15 +105,23 @@ ArObject *prefix##name##_fn(ArObject *func, ArObject *self, ArObject **argv, ArS
 #define ARGON_METHOD_SENTINEL   {nullptr, nullptr, nullptr, 0, false}
 
     enum class NativeMemberType {
-        // TODO: fill
+        AROBJECT,
+        DOUBLE,
+        FLOAT,
+        INT,
+        LONG,
+        SHORT,
+        STRING
     };
 
     struct NativeMember {
         const char *name;
-        int offset;
         NativeMemberType type;
+        int offset;
         bool readonly;
     };
+
+#define ARGON_MEMBER_SENTINEL {nullptr, (NativeMemberType)0, 0, false}
 
     using BufferGetFn = bool (*)(struct ArObject *obj, ArBuffer *buffer, ArBufferFlags flags);
     using BufferRelFn = void (*)(ArBuffer *buffer);

--- a/src/object/datatype/bool.cc
+++ b/src/object/datatype/bool.cc
@@ -44,7 +44,8 @@ const ObjectSlots bool_obj{
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 bool bool_is_true(Bool *self) {

--- a/src/object/datatype/bool.cc
+++ b/src/object/datatype/bool.cc
@@ -45,6 +45,7 @@ const ObjectSlots bool_obj{
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/bytes.cc
+++ b/src/object/datatype/bytes.cc
@@ -571,6 +571,7 @@ const ObjectSlots bytes_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/bytes.cc
+++ b/src/object/datatype/bytes.cc
@@ -570,7 +570,8 @@ const ObjectSlots bytes_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 ArObject *bytes_add(Bytes *self, ArObject *other) {

--- a/src/object/datatype/decimal.cc
+++ b/src/object/datatype/decimal.cc
@@ -91,6 +91,7 @@ const ObjectSlots decimal_obj{
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/decimal.cc
+++ b/src/object/datatype/decimal.cc
@@ -90,7 +90,8 @@ const ObjectSlots decimal_obj{
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 ArObject *decimal_add(ArObject *left, ArObject *right) {

--- a/src/object/datatype/error.cc
+++ b/src/object/datatype/error.cc
@@ -81,6 +81,11 @@ const NativeFunc error_methods[] = {
         ARGON_METHOD_SENTINEL
 };
 
+const NativeMember error_members[] = {
+        {"error",  NativeMemberType::AROBJECT, offsetof(Error, obj), true},
+        ARGON_MEMBER_SENTINEL
+};
+
 const TypeInfo *error_bases[] = {
         type_error_wrap_,
         nullptr
@@ -88,7 +93,7 @@ const TypeInfo *error_bases[] = {
 
 const ObjectSlots error_obj = {
         error_methods,
-        nullptr,
+        error_members,
         error_bases,
         nullptr,
         nullptr,
@@ -130,7 +135,7 @@ const TypeInfo name = {                         \
     #name,                                      \
     #doc,                                       \
     sizeof(Error),                              \
-    TypeInfoFlags::BASE,                        \
+    TypeInfoFlags::STRUCT,                      \
     nullptr,                                    \
     (VoidUnaryOp)error_cleanup,                 \
     nullptr,                                    \

--- a/src/object/datatype/error.cc
+++ b/src/object/datatype/error.cc
@@ -36,6 +36,7 @@ const ObjectSlots error_t_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 
@@ -87,6 +88,7 @@ const TypeInfo *error_bases[] = {
 
 const ObjectSlots error_obj = {
         error_methods,
+        nullptr,
         error_bases,
         nullptr,
         nullptr,

--- a/src/object/datatype/error.cc
+++ b/src/object/datatype/error.cc
@@ -35,7 +35,8 @@ const ObjectSlots error_t_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 const TypeInfo ErrorWrap = {
@@ -90,7 +91,8 @@ const ObjectSlots error_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 ArObject *error_compare(Error *self, ArObject *other, CompareMode mode) {

--- a/src/object/datatype/integer.cc
+++ b/src/object/datatype/integer.cc
@@ -93,7 +93,8 @@ const ObjectSlots integer_obj{
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 ArObject *integer_add(ArObject *left, ArObject *right) {

--- a/src/object/datatype/integer.cc
+++ b/src/object/datatype/integer.cc
@@ -94,6 +94,7 @@ const ObjectSlots integer_obj{
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/io/io.cc
+++ b/src/object/datatype/io/io.cc
@@ -428,6 +428,7 @@ const ObjectSlots file_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/io/io.cc
+++ b/src/object/datatype/io/io.cc
@@ -427,7 +427,8 @@ const ObjectSlots file_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 bool file_istrue(File *self) {

--- a/src/object/datatype/list.cc
+++ b/src/object/datatype/list.cc
@@ -432,6 +432,7 @@ const ObjectSlots list_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/list.cc
+++ b/src/object/datatype/list.cc
@@ -431,7 +431,8 @@ const ObjectSlots list_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 bool list_is_true(List *self) {

--- a/src/object/datatype/map.cc
+++ b/src/object/datatype/map.cc
@@ -275,6 +275,7 @@ const ObjectSlots map_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/map.cc
+++ b/src/object/datatype/map.cc
@@ -274,7 +274,8 @@ const ObjectSlots map_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 bool map_is_true(Map *self) {

--- a/src/object/datatype/module.cc
+++ b/src/object/datatype/module.cc
@@ -71,6 +71,7 @@ const ObjectSlots module_oslots = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         (BinaryOp) module_get_static_attr,
         nullptr,
         (BoolTernOp) module_set_static_attr,

--- a/src/object/datatype/module.cc
+++ b/src/object/datatype/module.cc
@@ -73,7 +73,8 @@ const ObjectSlots module_oslots = {
         nullptr,
         (BinaryOp) module_get_static_attr,
         nullptr,
-        (BoolTernOp) module_set_static_attr
+        (BoolTernOp) module_set_static_attr,
+        -1
 };
 
 ArObject *module_str(Module *self) {

--- a/src/object/datatype/nativewrap.cc
+++ b/src/object/datatype/nativewrap.cc
@@ -1,0 +1,196 @@
+// This source file is part of the Argon project.
+//
+// Licensed under the Apache License v2.0
+
+#include <memory/memory.h>
+
+#include <vm/runtime.h>
+
+#include "decimal.h"
+#include "error.h"
+#include "integer.h"
+#include "nil.h"
+#include "string.h"
+
+#include "nativewrap.h"
+
+using namespace argon::object;
+
+const char *NativeTypeStr[] = {"arobject", "double", "float", "int", "long", "short", "string"};
+
+const TypeInfo NativeWrapperType = {
+        TYPEINFO_STATIC_INIT,
+        "NativeWrapper",
+        nullptr,
+        sizeof(NativeWrapper),
+        TypeInfoFlags::STRUCT,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr
+};
+const TypeInfo *argon::object::type_native_wrapper_ = &NativeWrapperType;
+
+NativeWrapper *argon::object::NativeWrapperNew(const NativeMember *member) {
+    auto *native = ArObjectNew<NativeWrapper>(RCType::INLINE, type_native_wrapper_);
+    ArSize lname = strlen(member->name);
+
+    if (native != nullptr) {
+        if ((native->name = (char *) memory::Alloc(lname)) == nullptr) {
+            Release(native);
+            return nullptr;
+        }
+
+        memory::MemoryCopy(native->name, member->name, lname);
+        native->mtype = member->type;
+        native->offset = member->offset;
+        native->readonly = member->readonly;
+    }
+
+    return native;
+}
+
+#define offset (((unsigned char*)native) + wrapper->offset)
+
+ArObject *argon::object::NativeWrapperGet(const NativeWrapper *wrapper, const ArObject *native) {
+    ArObject *obj = nullptr;
+    void *tmp;
+
+    switch (wrapper->mtype) {
+        case NativeMemberType::AROBJECT:
+            if ((tmp = *((ArObject **) offset)) != nullptr)
+                obj = IncRef((ArObject *) tmp);
+            else
+                obj = IncRef(NilVal);
+            break;
+        case NativeMemberType::DOUBLE:
+            obj = DecimalNew(*((double *) offset));
+            break;
+        case NativeMemberType::FLOAT:
+            obj = DecimalNew(*((float *) offset));
+            break;
+        case NativeMemberType::INT:
+            obj = IntegerNew(*((int *) offset));
+            break;
+        case NativeMemberType::LONG:
+            obj = IntegerNew(*((long *) offset));
+            break;
+        case NativeMemberType::SHORT:
+            obj = IntegerNew(*((short *) offset));
+            break;
+        case NativeMemberType::STRING:
+            if ((tmp = *((char **) offset)) != nullptr)
+                obj = StringNew((char *) tmp);
+            else
+                obj = IncRef(NilVal);
+            break;
+    }
+
+    return obj;
+}
+
+bool ExtractNumberOrError(const NativeWrapper *wrapper, const ArObject *native, const ArObject *value,
+                          IntegerUnderlying *integer, DecimalUnderlying *decimal) {
+    if (AR_TYPEOF(value, type_integer_)) {
+        if (integer != nullptr)
+            *integer = ((Integer *) value)->integer;
+        else
+            *decimal = (DecimalUnderlying) ((Integer *) value)->integer;
+        return true;
+    }
+
+    if (AR_TYPEOF(value, type_decimal_)) {
+        if (integer != nullptr)
+            *integer = (IntegerUnderlying) ((Decimal *) value)->decimal;
+        else
+            *decimal = ((Decimal *) value)->decimal;
+        return true;
+    }
+
+    ErrorFormat(type_type_error_, "no viable conversion from '%s' to %s::%s(%s)", AR_TYPE_NAME(value),
+                AR_TYPE_NAME(native), wrapper->name, NativeTypeStr[(int) wrapper->mtype]);
+    return false;
+}
+
+bool argon::object::NativeWrapperSet(const NativeWrapper *wrapper, const ArObject *native, ArObject *value) {
+    IntegerUnderlying integer;
+    DecimalUnderlying decimal;
+
+    if (wrapper->readonly) {
+        ErrorFormat(type_unassignable_error_, "%s::%s is read-only", AR_TYPE_NAME(native), wrapper->name);
+        return false;
+    }
+
+    switch (wrapper->mtype) {
+        case NativeMemberType::AROBJECT: {
+            auto **dst = (ArObject **) offset;
+            Release(*dst);
+            *dst = IncRef(value);
+            break;
+        }
+        case NativeMemberType::DOUBLE:
+            if (!ExtractNumberOrError(wrapper, native, value, nullptr, &decimal))
+                return false;
+            *((double *) offset) = (double) decimal;
+            break;
+        case NativeMemberType::FLOAT:
+            if (!ExtractNumberOrError(wrapper, native, value, nullptr, &decimal))
+                return false;
+            *((float *) offset) = (float) decimal;
+            break;
+        case NativeMemberType::INT:
+            if (!ExtractNumberOrError(wrapper, native, value, &integer, nullptr))
+                return false;
+            *((int *) offset) = (int) integer;
+            break;
+        case NativeMemberType::LONG:
+            if (!ExtractNumberOrError(wrapper, native, value, &integer, nullptr))
+                return false;
+            *((long *) offset) = (long) integer;
+            break;
+        case NativeMemberType::SHORT:
+            if (!ExtractNumberOrError(wrapper, native, value, &integer, nullptr))
+                return false;
+            *((short *) offset) = (short) integer;
+            break;
+        case NativeMemberType::STRING: {
+            auto **str = (unsigned char **) offset;
+            auto *repr = (String *) ToString(value);
+            unsigned char *tmp;
+
+            if (repr == nullptr)
+                return false;
+
+            if ((tmp = (unsigned char *) memory::Alloc(repr->len)) == nullptr) {
+                Release(repr);
+                argon::vm::Panic(error_out_of_memory);
+                return false;
+            }
+
+            memory::MemoryCopy(tmp, repr->buffer, repr->len);
+
+            Release(repr);
+            memory::Free(*str);
+            *str = tmp;
+            break;
+        }
+    }
+
+    return true;
+}
+
+#undef offset

--- a/src/object/datatype/nativewrap.h
+++ b/src/object/datatype/nativewrap.h
@@ -1,0 +1,28 @@
+// This source file is part of the Argon project.
+//
+// Licensed under the Apache License v2.0
+
+#ifndef ARGON_OBJECT_NATIVEWRAP_H_
+#define ARGON_OBJECT_NATIVEWRAP_H_
+
+#include <object/arobject.h>
+
+namespace argon::object{
+    struct NativeWrapper : ArObject {
+        char *name;
+        int offset;
+        NativeMemberType mtype;
+        bool readonly;
+    };
+
+    extern const TypeInfo *type_native_wrapper_;
+
+    NativeWrapper *NativeWrapperNew(const NativeMember *member);
+
+    ArObject *NativeWrapperGet(const NativeWrapper *wrapper, const ArObject *native);
+
+    bool NativeWrapperSet(const NativeWrapper *wrapper, const ArObject *native, ArObject *value);
+
+} // namespace argon::object
+
+#endif // !ARGON_OBJECT_NATIVEWRAP_H_

--- a/src/object/datatype/option.cc
+++ b/src/object/datatype/option.cc
@@ -66,7 +66,8 @@ const ObjectSlots option_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 void option_cleanup(Option *self) {

--- a/src/object/datatype/option.cc
+++ b/src/object/datatype/option.cc
@@ -67,6 +67,7 @@ const ObjectSlots option_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/set.cc
+++ b/src/object/datatype/set.cc
@@ -410,6 +410,7 @@ const ObjectSlots set_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/set.cc
+++ b/src/object/datatype/set.cc
@@ -409,7 +409,8 @@ const ObjectSlots set_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 bool set_is_true(Set *self) {

--- a/src/object/datatype/string.cc
+++ b/src/object/datatype/string.cc
@@ -547,6 +547,7 @@ const ObjectSlots str_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/object/datatype/string.cc
+++ b/src/object/datatype/string.cc
@@ -546,7 +546,8 @@ const ObjectSlots str_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 bool string_is_true(String *self) {

--- a/src/object/datatype/struct.cc
+++ b/src/object/datatype/struct.cc
@@ -51,88 +51,13 @@ NativeWrapper *argon::object::NativeWrapperNew(const NativeMember *member) {
     return native;
 }
 
-ArObject *struct_get_attr(Struct *self, ArObject *key) {
-    PropertyInfo pinfo{};
-    Namespace **ns = (Namespace **) AR_GET_NSOFF(self);
-
-    const TypeInfo *ancestor = AR_GET_TYPE(self);
-    const TypeInfo *type;
-
-    ArObject *instance = nullptr;
-    ArObject *obj;
-
-    obj = NamespaceGetValue(*ns, key, &pinfo);
-
-    if (argon::vm::GetRoutine()->frame != nullptr)
-        instance = argon::vm::GetRoutine()->frame->instance;
-
-    if (obj == nullptr) {
-
-        if (ancestor->tp_map != nullptr)
-            obj = NamespaceGetValue((Namespace *) ancestor->tp_map, key, &pinfo);
-
-        if (obj == nullptr && ancestor->mro != nullptr) {
-            for (ArSize i = 0; i < ((Tuple *) ancestor->mro)->len; i++) {
-                type = (TypeInfo *) ((Tuple *) ancestor->mro)->objects[i];
-
-                if (type->tp_map != nullptr) {
-                    if ((obj = NamespaceGetValue((Namespace *) type->tp_map, key, &pinfo)) != nullptr)
-                        break;
-                }
-            }
-        }
-
-        if (obj == nullptr)
-            return ErrorFormat(type_attribute_error_, "unknown attribute '%s' of instance '%s'",
-                               ((String *) key)->buffer, ancestor->name);
-    }
-
-    if (!pinfo.IsPublic() && !TraitIsImplemented(instance, ancestor)) {
-        ErrorFormat(type_access_violation_, "access violation, member '%s' of '%s' are private",
-                    ((String *) key)->buffer, ancestor->name);
-        Release(obj);
-        return nullptr;
-    }
-
-    return obj;
-}
-
-ArObject *struct_get_static_attr(Struct *self, ArObject *key) {
-    const TypeInfo *ancestor = AR_GET_TYPE(self)->type;
-
-    return ancestor->obj_actions->get_static_attr((ArObject *) AR_GET_TYPE(self), key);
-}
-
-bool struct_set_attr(Struct *self, ArObject *key, ArObject *value) {
-    PropertyInfo pinfo{};
-    Namespace **ns = (Namespace **) AR_GET_NSOFF(self);
-    ArObject *instance = nullptr;
-
-    if (argon::vm::GetRoutine()->frame != nullptr)
-        instance = argon::vm::GetRoutine()->frame->instance;
-
-    if (!NamespaceContains(*ns, key, &pinfo)) {
-        ErrorFormat(type_attribute_error_, "unknown attribute '%s' of instance '%s'", ((String *) key)->buffer,
-                    AR_TYPE_NAME(self));
-        return false;
-    }
-
-    if (!pinfo.IsPublic() && instance != self) {
-        ErrorFormat(type_access_violation_, "access violation, member '%s' of '%s' are private",
-                    ((String *) key)->buffer, AR_TYPE_NAME(self));
-        return false;
-    }
-
-    return NamespaceSetValue(*ns, key, value);
-}
-
 const ObjectSlots struct_actions{
         nullptr,
         nullptr,
         nullptr,
-        (BinaryOp) struct_get_attr,
-        (BinaryOp) struct_get_static_attr,
-        (BoolTernOp) struct_set_attr,
+        nullptr,
+        nullptr,
+        nullptr,
         nullptr,
         offsetof(Struct, names)
 };

--- a/src/object/datatype/struct.cc
+++ b/src/object/datatype/struct.cc
@@ -11,46 +11,6 @@
 using namespace argon::object;
 using namespace argon::memory;
 
-const TypeInfo NativeWrapperType = {
-        TYPEINFO_STATIC_INIT,
-        "NativeWrapper",
-        nullptr,
-        sizeof(NativeWrapper),
-        TypeInfoFlags::STRUCT,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr
-};
-const TypeInfo *argon::object::type_native_wrapper_ = &NativeWrapperType;
-
-NativeWrapper *argon::object::NativeWrapperNew(const NativeMember *member) {
-    auto *native = ArObjectNew<NativeWrapper>(RCType::INLINE, type_native_wrapper_);
-
-    if (native != nullptr) {
-        native->name = member->name; // TODO: Copy!!
-        native->offset = member->offset;
-        native->mtype = member->type;
-        native->readonly = member->readonly;
-    }
-
-    return native;
-}
-
 const ObjectSlots struct_actions{
         nullptr,
         nullptr,

--- a/src/object/datatype/struct.cc
+++ b/src/object/datatype/struct.cc
@@ -90,7 +90,8 @@ const ObjectSlots struct_actions{
         (BinaryOp) struct_get_attr,
         (BinaryOp) struct_get_static_attr,
         (BoolTernOp) struct_set_attr,
-        nullptr
+        nullptr,
+        -1
 };
 
 ArObject *struct_str(Struct *self) {

--- a/src/object/datatype/struct.cc
+++ b/src/object/datatype/struct.cc
@@ -11,6 +11,46 @@
 using namespace argon::object;
 using namespace argon::memory;
 
+const TypeInfo NativeWrapperType = {
+        TYPEINFO_STATIC_INIT,
+        "NativeWrapper",
+        nullptr,
+        sizeof(NativeWrapper),
+        TypeInfoFlags::STRUCT,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr
+};
+const TypeInfo *argon::object::type_native_wrapper_ = &NativeWrapperType;
+
+NativeWrapper *argon::object::NativeWrapperNew(const NativeMember *member) {
+    auto *native = ArObjectNew<NativeWrapper>(RCType::INLINE, type_native_wrapper_);
+
+    if (native != nullptr) {
+        native->name = member->name; // TODO: Copy!!
+        native->offset = member->offset;
+        native->mtype = member->type;
+        native->readonly = member->readonly;
+    }
+
+    return native;
+}
+
 ArObject *struct_get_attr(Struct *self, ArObject *key) {
     PropertyInfo pinfo{};
 
@@ -85,6 +125,7 @@ bool struct_set_attr(Struct *self, ArObject *key, ArObject *value) {
 }
 
 const ObjectSlots struct_actions{
+        nullptr,
         nullptr,
         nullptr,
         (BinaryOp) struct_get_attr,

--- a/src/object/datatype/struct.h
+++ b/src/object/datatype/struct.h
@@ -16,9 +16,7 @@ namespace argon::object {
 
     extern const TypeInfo *type_struct_;
 
-    Struct *StructInitPositional(TypeInfo *type, ArObject **values, ArSize count);
-
-    Struct *StructInitKeyPair(TypeInfo *type, ArObject **values, ArSize count);
+    ArObject *StructInit(const TypeInfo *type, ArObject **values, ArSize count, bool keypair);
 
 } // namespace argon::object
 

--- a/src/object/datatype/struct.h
+++ b/src/object/datatype/struct.h
@@ -16,9 +16,9 @@ namespace argon::object {
 
     extern const TypeInfo *type_struct_;
 
-    Struct *StructNewPositional(TypeInfo *type, ArObject **values, ArSize count);
+    Struct *StructInitPositional(TypeInfo *type, ArObject **values, ArSize count);
 
-    Struct *StructNewKeyPair(TypeInfo *type, ArObject **values, ArSize count);
+    Struct *StructInitKeyPair(TypeInfo *type, ArObject **values, ArSize count);
 
 } // namespace argon::object
 

--- a/src/object/datatype/struct.h
+++ b/src/object/datatype/struct.h
@@ -16,6 +16,17 @@ namespace argon::object {
 
     extern const TypeInfo *type_struct_;
 
+    struct NativeWrapper : ArObject {
+        const char *name;
+        int offset;
+        NativeMemberType mtype;
+        bool readonly;
+    };
+
+    extern const TypeInfo *type_native_wrapper_;
+
+    NativeWrapper *NativeWrapperNew(const NativeMember *member);
+
     Struct *StructNewPositional(TypeInfo *type, ArObject **values, ArSize count);
 
     Struct *StructNewKeyPair(TypeInfo *type, ArObject **values, ArSize count);

--- a/src/object/datatype/struct.h
+++ b/src/object/datatype/struct.h
@@ -16,17 +16,6 @@ namespace argon::object {
 
     extern const TypeInfo *type_struct_;
 
-    struct NativeWrapper : ArObject {
-        const char *name;
-        int offset;
-        NativeMemberType mtype;
-        bool readonly;
-    };
-
-    extern const TypeInfo *type_native_wrapper_;
-
-    NativeWrapper *NativeWrapperNew(const NativeMember *member);
-
     Struct *StructNewPositional(TypeInfo *type, ArObject **values, ArSize count);
 
     Struct *StructNewKeyPair(TypeInfo *type, ArObject **values, ArSize count);

--- a/src/object/datatype/tuple.cc
+++ b/src/object/datatype/tuple.cc
@@ -117,7 +117,8 @@ const ObjectSlots tuple_obj = {
         nullptr,
         nullptr,
         nullptr,
-        nullptr
+        nullptr,
+        -1
 };
 
 bool tuple_is_true(Tuple *self) {

--- a/src/object/datatype/tuple.cc
+++ b/src/object/datatype/tuple.cc
@@ -118,6 +118,7 @@ const ObjectSlots tuple_obj = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         -1
 };
 

--- a/src/vm/areval.cc
+++ b/src/vm/areval.cc
@@ -572,10 +572,10 @@ ArObject *argon::vm::Eval(ArRoutine *routine) {
                 }
 
                 if (!key_pair) {
-                    if ((ret = StructNewPositional(t_struct, cu_frame->eval_stack - args, args)) == nullptr)
+                    if ((ret = StructInitPositional(t_struct, cu_frame->eval_stack - args, args)) == nullptr)
                         goto error;
                 } else {
-                    if ((ret = StructNewKeyPair(t_struct, cu_frame->eval_stack - args, args)) == nullptr)
+                    if ((ret = StructInitKeyPair(t_struct, cu_frame->eval_stack - args, args)) == nullptr)
                         goto error;
                 }
 

--- a/src/vm/areval.cc
+++ b/src/vm/areval.cc
@@ -571,13 +571,8 @@ ArObject *argon::vm::Eval(ArRoutine *routine) {
                     goto error;
                 }
 
-                if (!key_pair) {
-                    if ((ret = StructInitPositional(t_struct, cu_frame->eval_stack - args, args)) == nullptr)
-                        goto error;
-                } else {
-                    if ((ret = StructInitKeyPair(t_struct, cu_frame->eval_stack - args, args)) == nullptr)
-                        goto error;
-                }
+                if ((ret = StructInit(t_struct, cu_frame->eval_stack - args, args, key_pair)) == nullptr)
+                    goto error;
 
                 STACK_REWIND(args);
                 TOP_REPLACE(ret);


### PR DESCRIPTION
Adding this support requires the use of the 'offsetof' macro on non POD/standard-layout structures. This shouldn't be a problem for most compilers, as the data structures used are "trivially_copyable" but, in any case, compilers like GCC still generate a warning (suppressed using -Wno-invalid-offsetof).