### PR TITLE
Feature/module calling convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ import enum
 
 let NOBLE_GAS = ["Helium", "Neon", "Argon", "Krypton", "Xenon"]
 
-NOBLE_GAS |> enum::group_by((itm) => {
+NOBLE_GAS |> enum.group_by((itm) => {
     return itm |> len
 }) |> println
 

--- a/src/arlib/http/client.ar
+++ b/src/arlib/http/client.ar
@@ -8,7 +8,6 @@
 
 import io
 import http::utils
-import regex
 import socket
 
 from error import TypeError, ValueError
@@ -39,7 +38,7 @@ struct IncompleteResponse {
     }
 }
 
-pub trait HTTPConnection : io::Read, io::Write {
+pub trait HTTPConnection : io.Read, io.Write {
     pub func close()
 
     pub func connect(host, port)
@@ -64,14 +63,14 @@ pub struct HTTPSocket impl HTTPConnection {
     }
 
     pub func connect(host, port) {
-        var sock, err = socket::create(socket::AF_INET, socket::SOCK_STREAM, 0)
+        var sock, err = socket.create(socket.AF_INET, socket.SOCK_STREAM, 0)
         var hip
 
         if err != nil {
             return nil, err
         }
 
-        hip, err = socket::gethostbyname(host)
+        hip, err = socket.gethostbyname(host)
         if err != nil {
             return err
         }
@@ -127,14 +126,14 @@ pub struct HTTPSSocket impl HTTPConnection {
         }
 
         pub func connect(host, port) {
-            var sock, err = socket::create(socket::AF_INET, socket::SOCK_STREAM, 0)
+            var sock, err = socket.create(socket.AF_INET, socket.SOCK_STREAM, 0)
             var hip
 
             if err != nil {
                 return nil, err
             }
 
-            hip, err = socket::gethostbyname(host)
+            hip, err = socket.gethostbyname(host)
             if err != nil {
                 return err
             }
@@ -145,7 +144,7 @@ pub struct HTTPSSocket impl HTTPConnection {
             }
 
             self.connected = true
-            self.sock = ssl::DEFAULT_CONTEXT.wrap(sock, false, nil)
+            self.sock = ssl.DEFAULT_CONTEXT.wrap(sock, false, nil)
         }
 
         pub func isconnected() {
@@ -188,7 +187,7 @@ pub struct Request {
     var status = @IDLE # Can be one of these: IDLE, REQUEST, REQUESTED
 
     pub let new = (host, port, hconn) => {
-        var dest, err = utils::split_host_port(host, port, Request::DEFAULT_PORT)
+        var dest, err = utils.split_host_port(host, port, Request::DEFAULT_PORT)
         if err != nil {
             return nil, err
         }
@@ -242,7 +241,7 @@ pub struct Request {
         }
 
         # File-like object
-        if isimpl(body, io::Read) {
+        if isimpl(body, io.Read) {
             return nil
         }
 
@@ -286,13 +285,13 @@ pub struct Request {
     func prepare_request(method, url, headers) {
         var err
 
-        if utils::METHOD_DISALLOWED_CHAR.search(method) {
+        if utils.METHOD_DISALLOWED_CHAR.search(method) {
             return "method can't contain control characters"
         }
 
         url = url ?: "/"
 
-        if utils::PATH_DISALLOWED_CHAR.search(url) {
+        if utils.PATH_DISALLOWED_CHAR.search(url) {
             return "path can't contain control characters"
         }
 
@@ -456,7 +455,7 @@ pub struct Request {
                 return
             }
 
-            if isimpl(body, io::Read) {
+            if isimpl(body, io.Read) {
                 return self.send_file(body)
             }
 
@@ -513,7 +512,7 @@ pub struct Request {
             return "can't set up tunnel for established connection"
         }
 
-        self.tu_dest, err = utils::split_host_port(host, port, Request::DEFAULT_PORT)
+        self.tu_dest, err = utils.split_host_port(host, port, Request.DEFAULT_PORT)
         if err != nil {
             return err
         }
@@ -530,11 +529,11 @@ pub struct Request {
 
         var header, value
         for header, value in self.tu_headers {
-            if !utils::HEADER_VALID_NAME.match(header) {
+            if !utils.HEADER_VALID_NAME.match(header) {
                 return "invalid header name: %s" % header
             }
 
-            if utils::HEADER_INVALID_VALUE.match(value) {
+            if utils.HEADER_INVALID_VALUE.match(value) {
                 return "invalid header value: %s: %s" % (header, value)
             }
 
@@ -565,11 +564,11 @@ pub struct Request {
     }
 
     func write_header(key, value) {
-        if !utils::HEADER_VALID_NAME.match(key) {
+        if !utils.HEADER_VALID_NAME.match(key) {
             return "invalid header name: %s" % key
         }
 
-        if utils::HEADER_INVALID_VALUE.match(value) {
+        if utils.HEADER_INVALID_VALUE.match(value) {
             return "invalid header value: %s: %s" % (key, value)
         }
 
@@ -591,7 +590,7 @@ pub struct Request {
     }
 }
 
-pub struct Response impl io::Read {
+pub struct Response impl io.Read {
     var cxn
     var bufio
     var method
@@ -608,7 +607,7 @@ pub struct Response impl io::Read {
     pub var will_close
 
     pub let new = (cxn, method) => {
-        var response = Response{cxn, io::BufferedReader::new(cxn, 0), method}
+        var response = Response{cxn, io.BufferedReader::new(cxn, 0), method}
         var err = response.process()
         if err != nil {
             return nil, err

--- a/src/arlib/http/utils.ar
+++ b/src/arlib/http/utils.ar
@@ -9,14 +9,14 @@
 
 import regex
 
-pub let HEADER_VALID_NAME = regex::compile(r#"[^:\s][^:\r\n]*"#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
-pub let HEADER_INVALID_VALUE = regex::compile(r#"\n(?![ \t])|\r(?![ \t\n])"#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
+pub let HEADER_VALID_NAME = regex.compile(r#"[^:\s][^:\r\n]*"#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
+pub let HEADER_INVALID_VALUE = regex.compile(r#"\n(?![ \t])|\r(?![ \t\n])"#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
 
 # Prevent http header injection.
-pub let METHOD_DISALLOWED_CHAR = regex::compile(r#"[\x00-\x1f]"#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
+pub let METHOD_DISALLOWED_CHAR = regex.compile(r#"[\x00-\x1f]"#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
 
 # Prevent CVE-2019-9740.
-pub let PATH_DISALLOWED_CHAR = regex::compile(r#"[\x00-\x20\x7f]"#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
+pub let PATH_DISALLOWED_CHAR = regex.compile(r#"[\x00-\x20\x7f]"#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
 
 pub func split_host_port(host, port, default_port) {
     var colon = host.rfind(":")

--- a/src/arlib/ini.ar
+++ b/src/arlib/ini.ar
@@ -52,10 +52,10 @@ import regex
 
 from error import TypeError
 
-let INI_COMMENTS = regex::compile(r#"\s*[;|#].*"#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
-let INI_SECTION = regex::compile(r#"\s*\[(.+?)\]\s*$"#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
-let INI_KONLY = regex::compile(r#"\s*(.+)?\s*$"#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
-let INI_KV = regex::compile(r#"\s*(.+?)\s*[=|:]\s*(.+)*$"#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
+let INI_COMMENTS = regex.compile(r#"\s*[;|#].*"#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
+let INI_SECTION = regex.compile(r#"\s*\[(.+?)\]\s*$"#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
+let INI_KONLY = regex.compile(r#"\s*(.+)?\s*$"#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
+let INI_KV = regex.compile(r#"\s*(.+?)\s*[=|:]\s*(.+)*$"#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
 
 struct Section {
     pub var name
@@ -296,7 +296,7 @@ pub struct IniParser {
     pub func read(data) {
         self.line = 0
 
-        if isimpl(data, io::TextInput) {
+        if isimpl(data, io.TextInput) {
             return self.read_file(data)
         }
 

--- a/src/arlib/json/decoder.ar
+++ b/src/arlib/json/decoder.ar
@@ -9,7 +9,7 @@
 import regex
 from json::scanner import Scanner, ScannerCallback, DecodeError, skip_spaces
 
-let STRING_RE = regex::compile(r#".*?[^\\]""#, regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
+let STRING_RE = regex.compile(r#".*?[^\\]""#, regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
 
 pub struct Decoder impl ScannerCallback {
     pub func parse_array(scanner, buffer, index) {

--- a/src/arlib/json/encoder.ar
+++ b/src/arlib/json/encoder.ar
@@ -52,13 +52,13 @@ pub struct Encoder {
 			buffer += b"\"%s\"" % obj
 			return buffer
 		case decimal:
-			if obj == math::nan {
+			if obj == math.nan {
 				buffer += b"NaN"
 				return buffer
-			} elif obj == math::inf {
+			} elif obj == math.inf {
 				buffer += b"Infinity"
 				return buffer
-			} elif obj == -math::inf {
+			} elif obj == -math.inf {
 				buffer += b"-Infinity"
 				return buffer
 			}

--- a/src/arlib/json/json.ar
+++ b/src/arlib/json/json.ar
@@ -15,7 +15,7 @@ pub func decode(json) {
 
     if type(json) != bytes {
         if type(json) != string {
-            panic "json::decode expected string or bytes, not %s" % type(json)
+            panic "json.decode expected string or bytes, not %s" % type(json)
         }
 
         json = bytes::new(json)

--- a/src/arlib/json/scanner.ar
+++ b/src/arlib/json/scanner.ar
@@ -10,7 +10,7 @@ import regex
 import math
 from error import NotImplemented
 
-let NUMBER_RE = regex::compile("(-?(?:0|[1-9]\d*))(\.\d+)?([eE][-+]?\d+)?", regex::MODE_ECMASCRIPT | regex::OPTIMIZE)
+let NUMBER_RE = regex.compile("(-?(?:0|[1-9]\d*))(\.\d+)?([eE][-+]?\d+)?", regex.MODE_ECMASCRIPT | regex.OPTIMIZE)
 
 pub trait ScannerCallback {
     pub func parse_array(scanner, buffer, index)
@@ -101,15 +101,15 @@ pub struct Scanner {
                 }
             case 'N':
                 if buffer[index:index + 3] == b"NaN" {
-                    return math::nan, index + 3
+                    return math.nan, index + 3
                 }
             case 'I':
                 if buffer[index:index + 8] == b"Infinity" {
-                    return math::inf, index + 8
+                    return math.inf, index + 8
                 }
             case '-':
                 if buffer[index:index + 9] == b"-Infinity" {
-                    return -math::inf, index + 9
+                    return -math.inf, index + 9
                 }
         }
 

--- a/src/arlib/random.ar
+++ b/src/arlib/random.ar
@@ -32,7 +32,7 @@ pub func _randbelow(engine, num) {
     var rd
 
     if !isimpl(engine, Random) {
-        panic error::TypeError::new("invalid engine for _randbelow")
+        panic error.TypeError::new("invalid engine for _randbelow")
     }
 
     if num == 0 {
@@ -55,22 +55,22 @@ pub func _randrange(engine, start, stop, step) {
     var istep
 
     if !isimpl(engine, Random) {
-        panic error::TypeError::new("invalid engine for _randrange")
+        panic error.TypeError::new("invalid engine for _randrange")
     }
 
     istart = integer::new(start)
     if start != istart {
-        panic error::ValueError::new("non-integer start for _randrange")
+        panic error.ValueError::new("non-integer start for _randrange")
     }
 
     istop = integer::new(stop)
     if stop != istop {
-        panic error::ValueError::new("non-integer stop for _randrange")
+        panic error.ValueError::new("non-integer stop for _randrange")
     }
 
     istep = integer::new(step)
     if step != istep {
-        panic error::ValueError::new("non-integer step for _randrange")
+        panic error.ValueError::new("non-integer step for _randrange")
     }
 
     var width = istop - istart
@@ -80,7 +80,7 @@ pub func _randrange(engine, start, stop, step) {
             return istart + _randbelow(engine, width)
         }
 
-        panic error::ValueError::new("empty range for _randrange (%d, %d, %d)" % (istart, istop, width))
+        panic error.ValueError::new("empty range for _randrange (%d, %d, %d)" % (istart, istop, width))
     }
 
     var n
@@ -90,11 +90,11 @@ pub func _randrange(engine, start, stop, step) {
         case istep < 0:
             n = (width + istep + 1) // istep
         default:
-            panic error::ValueError::new("zero step for _randrange")
+            panic error.ValueError::new("zero step for _randrange")
     }
 
     if n <= 0 {
-        panic error::ValueError::new("empty range for _randrange")
+        panic error.ValueError::new("empty range for _randrange")
     }
 
     return istart + istep * _randbelow(engine, n)
@@ -104,7 +104,7 @@ pub func _randrange(engine, start, stop, step) {
 
 pub func _randbytes(engine, length) {
     if !isimpl(engine, Random) {
-        panic error::TypeError::new("invalid engine for _randbytes")
+        panic error.TypeError::new("invalid engine for _randbytes")
     }
 
     var bts = bytes::new(length)
@@ -120,7 +120,7 @@ pub func _randbytes(engine, length) {
 
 pub func _randlist(engine, start, stop, step, length) {
     if !isimpl(engine, Random) {
-        panic error::TypeError::new("invalid engine for _randlist")
+        panic error.TypeError::new("invalid engine for _randlist")
     }
 
     var ls = [0] * length
@@ -134,7 +134,7 @@ pub func _randlist(engine, start, stop, step, length) {
 
 pub func _randchoice(engine, seq) {
     if !isimpl(engine, Random) {
-        panic error::TypeError::new("invalid engine for _randchoice")
+        panic error.TypeError::new("invalid engine for _randchoice")
     }
 
     return seq[_randbelow(engine, len(seq))]
@@ -145,19 +145,19 @@ pub func _randsample(engine, population, k) {
     var plen = len(population)
 
     if !isimpl(engine, Random) {
-        panic error::TypeError::new("invalid engine for _randsample")
+        panic error.TypeError::new("invalid engine for _randsample")
     }
 
     if k < 0 {
-        panic error::ValueError::new("k is negative")
+        panic error.ValueError::new("k is negative")
     }
 
     if ik != k {
-        panic error::ValueError::new("non-integer k for _randsample")
+        panic error.ValueError::new("non-integer k for _randsample")
     }
 
     if ik > len(population) {
-        panic error::ValueError::new("sample larger than population")
+        panic error.ValueError::new("sample larger than population")
     }
 
     var sample = [nil] * ik

--- a/src/arlib/ssl.ar
+++ b/src/arlib/ssl.ar
@@ -15,7 +15,7 @@ struct X509v3Purpose {
     let CLIENT_AUTH = "1.3.6.1.5.5.7.3.2"
 }
 
-if runtime::os == "windows" {
+if runtime.os == "windows" {
     pub let WINDOWS_CERT_STORES = ["CA", "ROOT"]
 
     var certs = bytes::new()
@@ -24,7 +24,7 @@ if runtime::os == "windows" {
 
     for store in WINDOWS_CERT_STORES {
         for cert, encoding, trust in enumcerts_windows(store) {
-            if encoding == "x509_asn" && trust || trust.contains(X509v3Purpose::SERVER_AUTH) {
+            if encoding == "x509_asn" && trust || trust.contains(X509v3Purpose.SERVER_AUTH) {
                 certs += cert
             }
         }
@@ -40,7 +40,7 @@ pub func connect(address) {
     var sock
     var err
 
-    sock, err = socket::dial("tcp", address)
+    sock, err = socket.dial("tcp", address)
     if err != nil {
         return nil, err
     }

--- a/src/arlib/sync.ar
+++ b/src/arlib/sync.ar
@@ -26,7 +26,7 @@ pub struct Once {
     var mutex
 
     pub let new = () => {
-        return Once{false, Mutex::new()}
+        return Once{false, Mutex.new()}
     }
 
     pub func do(fn) {

--- a/src/lang/compiler/translation_unit.cc
+++ b/src/lang/compiler/translation_unit.cc
@@ -11,11 +11,15 @@
 using namespace argon::lang::compiler;
 using namespace argon::object;
 
-bool MakeQName(TranslationUnit *prev, TranslationUnit *unit, String *name) {
+bool MakeQName(const TranslationUnit *prev, TranslationUnit *unit, String *name) {
+    const char *sep = ".";
     String *tmp;
 
     if (prev != nullptr && name != nullptr && !StringEmpty(name)) {
-        if ((tmp = StringConcat(prev->name, "::", true)) == nullptr)
+        if (prev->scope != TUScope::MODULE)
+            sep = "::";
+
+        if ((tmp = StringConcat(prev->name, sep, true)) == nullptr)
             return false;
 
         if ((unit->qname = StringConcat(tmp, name)) == nullptr) {

--- a/src/module/builtins.cc
+++ b/src/module/builtins.cc
@@ -97,7 +97,7 @@ ARGON_FUNCTION(dir,
         return nullptr;
 
     if (count > 0 && AR_TYPEOF(argv[0], type_module_))
-        return NamespaceMkInfo(((Module *) argv[0])->module_ns, PropertyType::PUBLIC);
+        return NamespaceMkInfo(((Module *) argv[0])->module_ns, PropertyType::PUBLIC, false);
 
     frame = argon::vm::GetFrame();
 
@@ -106,18 +106,18 @@ ARGON_FUNCTION(dir,
             return ListNew();
 
         if (frame->instance != nullptr)
-            ret = NamespaceMkInfo((Namespace *) AR_GET_TYPE(frame->instance)->tp_map, PropertyType{});
+            ret = NamespaceMkInfo((Namespace *) AR_GET_TYPE(frame->instance)->tp_map, PropertyType{}, true);
         else
-            ret = NamespaceMkInfo(frame->globals, PropertyType{});
+            ret = NamespaceMkInfo(frame->globals, PropertyType{}, false);
 
         Release(frame);
         return ret;
     }
 
     if (frame != nullptr && frame->instance != nullptr && AR_GET_TYPE(frame->instance) == AR_GET_TYPE(argv[0]))
-        ret = NamespaceMkInfo((Namespace *) AR_GET_TYPE(argv[0])->tp_map, PropertyType{});
+        ret = NamespaceMkInfo((Namespace *) AR_GET_TYPE(argv[0])->tp_map, PropertyType{}, true);
     else
-        ret = NamespaceMkInfo((Namespace *) AR_GET_TYPE(argv[0])->tp_map, PropertyType::PUBLIC);
+        ret = NamespaceMkInfo((Namespace *) AR_GET_TYPE(argv[0])->tp_map, PropertyType::PUBLIC, true);
 
     Release(frame);
 
@@ -285,9 +285,9 @@ ARGON_FUNCTION(lsattr,
     frame = argon::vm::GetFrame();
 
     if (frame != nullptr && frame->instance != nullptr && AR_GET_TYPE(frame->instance) == target)
-        ret = NamespaceMkInfo((Namespace *) target->tp_map, PropertyType{});
+        ret = NamespaceMkInfo((Namespace *) target->tp_map, PropertyType{}, true);
     else
-        ret = NamespaceMkInfo((Namespace *) target->tp_map, PropertyType::PUBLIC);
+        ret = NamespaceMkInfo((Namespace *) target->tp_map, PropertyType::PUBLIC, true);
 
     Release(frame);
 

--- a/src/module/socket/socket.cc
+++ b/src/module/socket/socket.cc
@@ -1136,7 +1136,7 @@ ArObject *blocking_get(const Socket *self) {
 }
 
 const NativeMember socket_members[] = {
-        ARGON_MEMBER_GETSET("blocking", (NativeMemberGet) blocking_get, nullptr, NativeMemberType::BOOL, true),
+        ARGON_MEMBER_GETSET("blocking", (NativeMemberGet) blocking_get, nullptr, NativeMemberType::BOOL),
         ARGON_MEMBER_SENTINEL
 };
 

--- a/src/module/ssl/sslcontext.cc
+++ b/src/module/ssl/sslcontext.cc
@@ -666,10 +666,8 @@ ArObject *session_ticket_get(SSLContext *context) {
 const NativeMember sslcontext_members[] = {
         ARGON_MEMBER("check_hostname", offsetof(SSLContext, check_hname), NativeMemberType::BOOL, true),
         ARGON_MEMBER("protocol", offsetof(SSLContext, protocol), NativeMemberType::INT, true),
-        ARGON_MEMBER_GETSET("security_level", (NativeMemberGet) security_level_get, nullptr,
-                            NativeMemberType::INT, true),
-        ARGON_MEMBER_GETSET("session_ticket", (NativeMemberGet) session_ticket_get, nullptr,
-                            NativeMemberType::INT, true),
+        ARGON_MEMBER_GETSET("security_level", (NativeMemberGet) security_level_get, nullptr, NativeMemberType::INT),
+        ARGON_MEMBER_GETSET("session_ticket", (NativeMemberGet) session_ticket_get, nullptr, NativeMemberType::INT),
         ARGON_MEMBER("sni_callback", offsetof(SSLContext, sni_callback), NativeMemberType::AROBJECT, true),
         ARGON_MEMBER("verify_mode", offsetof(SSLContext, verify_mode), NativeMemberType::INT, true),
         ARGON_MEMBER_SENTINEL

--- a/src/module/ssl/sslsocket.cc
+++ b/src/module/ssl/sslsocket.cc
@@ -278,16 +278,13 @@ ArObject *version_get(SSLSocket *self) {
 }
 
 const NativeMember sslsocket_members[] = {
-        ARGON_MEMBER_GETSET("alpn_selected", (NativeMemberGet) alpn_selected_get, nullptr,
-                            NativeMemberType::STRING, true),
-        ARGON_MEMBER_GETSET("cipher", (NativeMemberGet) cipher_get, nullptr, NativeMemberType::AROBJECT, true),
-        ARGON_MEMBER_GETSET("compression", (NativeMemberGet) compression_get, nullptr, NativeMemberType::STRING, true),
+        ARGON_MEMBER_GETSET("alpn_selected", (NativeMemberGet) alpn_selected_get, nullptr, NativeMemberType::STRING),
+        ARGON_MEMBER_GETSET("cipher", (NativeMemberGet) cipher_get, nullptr, NativeMemberType::AROBJECT),
+        ARGON_MEMBER_GETSET("compression", (NativeMemberGet) compression_get, nullptr, NativeMemberType::STRING),
         ARGON_MEMBER("hostname", offsetof(SSLSocket, hostname), NativeMemberType::AROBJECT, true),
-        ARGON_MEMBER_GETSET("session_reused", (NativeMemberGet) session_reused_get, nullptr,
-                            NativeMemberType::BOOL, true),
-        ARGON_MEMBER_GETSET("shared_cipher", (NativeMemberGet) shared_cipher_get, nullptr,
-                            NativeMemberType::AROBJECT, true),
-        ARGON_MEMBER_GETSET("version", (NativeMemberGet) version_get, nullptr, NativeMemberType::STRING, true),
+        ARGON_MEMBER_GETSET("session_reused", (NativeMemberGet) session_reused_get, nullptr, NativeMemberType::BOOL),
+        ARGON_MEMBER_GETSET("shared_cipher", (NativeMemberGet) shared_cipher_get, nullptr, NativeMemberType::AROBJECT),
+        ARGON_MEMBER_GETSET("version", (NativeMemberGet) version_get, nullptr, NativeMemberType::STRING),
         ARGON_MEMBER_SENTINEL
 };
 

--- a/src/object/arobject.cc
+++ b/src/object/arobject.cc
@@ -44,12 +44,15 @@ ArObject *MROSearch(const TypeInfo *type, ArObject *key, PropertyInfo *pinfo) {
 }
 
 ArObject *type_get_static_attr(ArObject *self, ArObject *key) {
-    const TypeInfo *type = AR_GET_TYPEOBJ(self);
+    auto *type = (const TypeInfo *) self;
     const TypeInfo *tp_base = type;
     const ArObject *instance = nullptr;
     ArObject *obj;
 
     PropertyInfo pinfo{};
+
+    if (!AR_TYPEOF(type, type_type_))
+        return ErrorFormat(type_type_error_, "a type is required, not an instance of %s", AR_TYPE_NAME(type));
 
     if (type->tp_map == nullptr && type->mro == nullptr)
         return ErrorFormat(type_attribute_error_, "type '%s' has no attributes", type->name);

--- a/src/object/arobject.cc
+++ b/src/object/arobject.cc
@@ -192,9 +192,9 @@ ArObject *type_size_get(const TypeInfo *self) {
 }
 
 const NativeMember type_members[] = {
-        ARGON_MEMBER_GETSET("__doc", (NativeMemberGet) type_doc_get, nullptr, NativeMemberType::AROBJECT, true),
-        ARGON_MEMBER_GETSET("__name", (NativeMemberGet) type_name_get, nullptr, NativeMemberType::AROBJECT, true),
-        ARGON_MEMBER_GETSET("__size", (NativeMemberGet) type_size_get, nullptr, NativeMemberType::AROBJECT, true),
+        ARGON_MEMBER_GETSET("__doc", (NativeMemberGet) type_doc_get, nullptr, NativeMemberType::AROBJECT),
+        ARGON_MEMBER_GETSET("__name", (NativeMemberGet) type_name_get, nullptr, NativeMemberType::AROBJECT),
+        ARGON_MEMBER_GETSET("__size", (NativeMemberGet) type_size_get, nullptr, NativeMemberType::AROBJECT),
         ARGON_MEMBER_SENTINEL
 };
 
@@ -472,7 +472,7 @@ bool CalculateMRO(TypeInfo *type, TypeInfo **bases, ArSize count) {
 }
 
 ArObject *argon::object::ArObjectGCNew(const TypeInfo *type) {
-    auto obj =  GCNew(type->size);
+    auto obj = GCNew(type->size);
 
     if (obj != nullptr) {
         obj->ref_count = RefBits((unsigned char) RCType::GC);
@@ -822,7 +822,7 @@ bool InitMembers(TypeInfo *info) {
             if (nw == nullptr)
                 return false;
 
-            if (!NamespaceNewSymbol(ns, member->name, nw, PropertyType::CONST | PropertyType::PUBLIC)) {
+            if (!NamespaceNewSymbol(ns, member->name, nw, PropertyType::PUBLIC)) {
                 Release(nw);
                 return false;
             }

--- a/src/object/arobject.cc
+++ b/src/object/arobject.cc
@@ -168,7 +168,7 @@ bool type_set_attr(ArObject *obj, ArObject *key, ArObject *value) {
 
     Release(actual);
 
-    if (is_tpm) {
+    if (is_tpm || pinfo.IsConstant()) {
         ErrorFormat(type_unassignable_error_, "%s::%s is read-only", AR_TYPE_NAME(obj), ((String *) key)->buffer);
         return false;
     }
@@ -177,7 +177,7 @@ bool type_set_attr(ArObject *obj, ArObject *key, ArObject *value) {
 }
 
 ArObject *type_doc_get(const TypeInfo *self) {
-    if(self->doc == nullptr)
+    if (self->doc == nullptr)
         return StringIntern("");
 
     return StringNew(self->doc);
@@ -313,7 +313,8 @@ List *BuildBasesList(TypeInfo **types, ArSize count) {
 
         // Sanity check
         if (AR_GET_TYPE(types[i]) != type_type_) {
-            // is not a TypeInfo
+            ErrorFormat(type_type_error_, "you can only inherit from traits and '%s' is not",
+                        AR_GET_TYPE(types[i])->name);
             goto ERROR;
         }
 
@@ -433,7 +434,7 @@ Tuple *ComputeMRO(List *bases) {
 }
 
 bool CalculateMRO(TypeInfo *type, TypeInfo **bases, ArSize count) {
-    auto *mro = (Tuple *) type->mro;
+    const auto *mro = (Tuple *) type->mro;
     List *merge = nullptr;
     List *bases_list;
 
@@ -471,7 +472,7 @@ bool CalculateMRO(TypeInfo *type, TypeInfo **bases, ArSize count) {
 }
 
 ArObject *argon::object::ArObjectGCNew(const TypeInfo *type) {
-    auto obj = (ArObject *) GCNew(type->size);
+    auto obj =  GCNew(type->size);
 
     if (obj != nullptr) {
         obj->ref_count = RefBits((unsigned char) RCType::GC);

--- a/src/object/arobject.h
+++ b/src/object/arobject.h
@@ -133,7 +133,7 @@ ArObject *prefix##name##_fn(ArObject *func, ArObject *self, ArObject **argv, ArS
     };
 
 #define ARGON_MEMBER(name, offset, type, readonly)          {name, nullptr, nullptr, offset, type, readonly}
-#define ARGON_MEMBER_GETSET(name, get, set, type, readonly) {name, get, set, -1, type, readonly}
+#define ARGON_MEMBER_GETSET(name, get, set, type)           {name, get, set, -1, type, false}
 #define ARGON_MEMBER_SENTINEL                               {nullptr, nullptr, nullptr, -1, (NativeMemberType)0, false}
 
     using BufferGetFn = bool (*)(struct ArObject *obj, ArBuffer *buffer, ArBufferFlags flags);

--- a/src/object/datatype/function.cc
+++ b/src/object/datatype/function.cc
@@ -131,17 +131,10 @@ void function_cleanup(Function *fn) {
     Release(fn->gns);
 }
 
-ArObject *function_get_code(const Function *self) {
-    if (self->IsNative())
-        return BytesNew();
-
-    return BytesNew(self->code->instr, self->code->instr_sz, true);
-}
-
 const NativeMember function_members[] = {
         ARGON_MEMBER("__arity", offsetof(Function, arity), NativeMemberType::SHORT, true),
         ARGON_MEMBER("__base", offsetof(Function, base), NativeMemberType::AROBJECT, true),
-        ARGON_MEMBER_GETSET("__code", (NativeMemberGet) function_get_code, nullptr, NativeMemberType::AROBJECT, true),
+        ARGON_MEMBER("__doc", offsetof(Function, doc), NativeMemberType::AROBJECT, true),
         ARGON_MEMBER("__name", offsetof(Function, name), NativeMemberType::AROBJECT, true),
         ARGON_MEMBER("__qname", offsetof(Function, qname), NativeMemberType::AROBJECT, true),
         ARGON_MEMBER_SENTINEL

--- a/src/object/datatype/namespace.cc
+++ b/src/object/datatype/namespace.cc
@@ -230,7 +230,7 @@ ArObject *argon::object::NamespaceGetValue(Namespace *ns, ArObject *key, Propert
     return nullptr;
 }
 
-List *argon::object::NamespaceMkInfo(Namespace *ns, PropertyType info) {
+List *argon::object::NamespaceMkInfo(Namespace *ns, PropertyType info, bool isinstance) {
     char buffer[10] = {};
     List *keys;
 
@@ -263,7 +263,7 @@ List *argon::object::NamespaceMkInfo(Namespace *ns, PropertyType info) {
                 snprintf(buffer, 10, "(%s)", fn->IsVariadic() ? "..." : "");
 
             key = StringNewFormat("%s%s%s",
-                                  fn->IsMethod() ? "" : "::",
+                                  isinstance && !fn->IsMethod() ? "::" : "",
                                   ((String *) cursor->key)->buffer,
                                   buffer);
 
@@ -276,7 +276,7 @@ List *argon::object::NamespaceMkInfo(Namespace *ns, PropertyType info) {
 
         if (!wr) {
             key = StringNewFormat("%s%s%s",
-                                  cursor->info.IsConstant() ? "::" : "",
+                                  isinstance && cursor->info.IsConstant() ? "::" : "",
                                   ((String *) cursor->key)->buffer,
                                   buffer);
         }

--- a/src/object/datatype/namespace.h
+++ b/src/object/datatype/namespace.h
@@ -106,7 +106,7 @@ namespace argon::object {
 
     ArObject *NamespaceGetValue(Namespace *ns, ArObject *key, PropertyInfo *info);
 
-    List *NamespaceMkInfo(Namespace *ns, PropertyType info);
+    List *NamespaceMkInfo(Namespace *ns, PropertyType info, bool isinstance);
 
     bool NamespaceMerge(Namespace *dst, Namespace *src);
 

--- a/src/vm/areval.cc
+++ b/src/vm/areval.cc
@@ -488,7 +488,7 @@ else                                            \
             {
                 auto attribute = (String *) TupleGetItem(cu_code->statics, ARG32);
 
-                if ((ret = PropertyGet(TOP(), attribute, false)) == nullptr) {
+                if ((ret = PropertyGet(TOP(), attribute, true)) == nullptr) {
                     Release(attribute);
                     goto ERROR;
                 }


### PR DESCRIPTION
The convention for accessing form values has changed from the '::' operator to the '.' operator.
This is necessary to make the syntax more harmonic and allow the use of the '?.' operator to access the values of a module. In addition, the use of the '::' operator has been restricted and its use is only possible on DataType instances (string, integer, struct and trait defined by the user).